### PR TITLE
fix: utm 5.0 support

### DIFF
--- a/builder/utm/common/driver.go
+++ b/builder/utm/common/driver.go
@@ -89,6 +89,8 @@ func NewDriver() (Driver, error) {
 		driver = &Utm46Driver{Utm45Driver{utmctlPath}}
 	case "4.7":
 		driver = &Utm47Driver{Utm46Driver{Utm45Driver{utmctlPath}}}
+	case "5.0":
+		driver = &Utm50Driver{Utm47Driver{Utm46Driver{Utm45Driver{utmctlPath}}}}
 	default:
 		log.Fatalf("Unsupported UTM version: %s", version)
 	}

--- a/builder/utm/common/driver_5_0.go
+++ b/builder/utm/common/driver_5_0.go
@@ -1,0 +1,8 @@
+package common
+
+// Utm50Driver are inherited from Utm47Driver.
+// UTM 5.0 keeps the same scripting interface as 4.7 (qemu additional
+// arguments, displays, serial ports, update configuration).
+type Utm50Driver struct {
+	Utm47Driver
+}


### PR DESCRIPTION
## Problem

UTM 5.0.x (currently in prerelease, and the only UTM that runs reliably on macOS 26 "Tahoe" — 4.7.5 segfaults in the macOS 26 UI frameworks during VM start) is rejected by the driver version switch in `NewDriver()`:

```
utmctl path: /opt/homebrew/bin/utmctl
UTM version: 5.0.3
Unsupported UTM version: 5.0.3
```

Because the rejection is a `log.Fatalf`, the plugin process exits and Packer reports it as:

```
Build 'otobots-base.utm-iso.debian13' errored after 207 milliseconds: unexpected EOF
```

## Fix for #51 

Add `Utm50Driver` inheriting from `Utm47Driver`, plus the matching `case "5.0"` — the same pattern used to add 4.7 support (#33).

UTM 5.0's AppleScript interface is unchanged for everything the driver uses: `qemu additional arguments`, `argument string`, `update configuration`, `displays`, and `serial ports` are all present in `UTM.sdef` shipped with UTM 5.0.3.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- End-to-end `utm-iso` build on macOS 26.5.2 (Apple Silicon) with UTM 5.0.3: Debian 13 arm64 netinst with preseed over the plugin's HTTP server. VM create, customize, disk/ISO attach, display attach, VNC arg injection via QEMU additional arguments, VM start, VNC boot-command typing, and the SSH communicator wait all work with the 4.7 driver behavior; the installer proceeds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code) after 2 days of debugging a packer build of Debian Trixie.
